### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include sdformat_tools/common2.sdf.xmacro
+include sdformat_tools/common.sdf.xmacro


### PR DESCRIPTION
There's a typo inside MANIFEST.in file

it want to include common2.sdf.xmacro instead of common.sdf.xmacro. 
This lead to compile failed when compiling this project and  universal_robot_ign  project. 